### PR TITLE
Springdocs를 활용하여 Swagger UI 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Spring Docs
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -2,6 +2,8 @@ package com.thetrustlesstrio.TrustSurveyServer.controller;
 
 import com.thetrustlesstrio.TrustSurveyServer.Survey;
 import com.thetrustlesstrio.TrustSurveyServer.SurveyRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import java.util.List;
 import java.util.Optional;
 
+@Tag(name = "Survey Controller", description = "Survey 관련 컨트롤러")
 @Controller
 public class SurveyController {
 
@@ -47,6 +50,7 @@ public class SurveyController {
         return test; // JSON API
     }
 
+    @Operation(summary = "mongo test", description = "Survey 2개를 Write 해보는 테스트 API")
     @GetMapping("mongo/test")
     @ResponseBody
     public List<Survey> mongoTest() {


### PR DESCRIPTION
참고한 레퍼런스
- https://devbksheen.tistory.com/entry/Spring-Docs-Swagger-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0-Spring-Rest-Docs-%EB%B9%84%EA%B5%90
- https://springdoc.org/v2/

Client에서 테스트를 할 때 직관적으로 API를 확인 및 테스트를 할 수 있게 Sprintdocs를 활용하여 Swagger을 적용시켰습니다.
아래 링크를 통해서 접속할 수 있습니다. (서버를 사용중이라면 localhost를 서버 주소로 변경)

http://localhost:8080/swagger-ui/index.html