### PR TITLE
Survey Register API, Survey List API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/RegisterSurveyDto.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/RegisterSurveyDto.java
@@ -1,27 +1,49 @@
 package com.thetrustlesstrio.TrustSurveyServer;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
 public class RegisterSurveyDto {
 
-    private String desc;
+    // TODO: use logged in session to get publisher's identity, instead of getting it from request json
+    @NotBlank
+    private String publisherWalletId; // wallet id of person who registered survey
+
+    @NotBlank
+    private String title;
+
+    private String summary; // short description which will be shown in survey card UI in main page
+
+    @NotBlank
+    private String desc; // long description
 
     private String privateAttendeeKey;
     private String publicAttendeeEmailPattern; // ex. '@kaist.ac.kr'
 
+    @NotNull
     private int maxAttendeeCount;
 
+    @Schema(type = "LocalDateTime", example = "2023-05-05T13:30:01Z")
     @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
     @NotNull
     private LocalDateTime automaticClosingDatetime;
 
+    @NotNull
     private boolean manualClosing;
+
+    @NotNull
     private int reward;
+
+    @NotEmpty
+    private List<String> questions;
 }

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/RegisterSurveyDto.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/RegisterSurveyDto.java
@@ -1,0 +1,27 @@
+package com.thetrustlesstrio.TrustSurveyServer;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class RegisterSurveyDto {
+
+    private String desc;
+
+    private String privateAttendeeKey;
+    private String publicAttendeeEmailPattern; // ex. '@kaist.ac.kr'
+
+    private int maxAttendeeCount;
+
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    @NotNull
+    private LocalDateTime automaticClosingDatetime;
+
+    private boolean manualClosing;
+    private int reward;
+}

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
@@ -1,12 +1,14 @@
 package com.thetrustlesstrio.TrustSurveyServer;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -15,6 +17,10 @@ public class Survey {
     @Id
     private String id;
 
+    private String publisherWalletId;
+
+    private String title;
+    private String summary;
     private String desc;
 
     private String privateAttendeeKey;
@@ -22,23 +28,33 @@ public class Survey {
 
     private int maxAttendeeCount;
 
+    @Schema(type = "LocalDateTime", example = "2023-05-05T13:30:01Z")
     @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
     private LocalDateTime automaticClosingDatetime;
 
     private boolean manualClosing;
     private int reward;
 
-    // TODO: 현재 참여자 목록 (계좌 id)
+    private List<String> questions;
+
+    // TODO: 현재 응답 목록 ((참여자1, 응답1), (참여자2, 응답2), ...) -> 게시자만 볼 수 있어야 하는 필드
 
     public Survey() {}
 
-    public Survey(String desc,
+    public Survey(String publisherWalletId,
+                  String title,
+                  String summary,
+                  String desc,
                   String privateAttendeeKey,
                   String publicAttendeeEmailPattern,
                   int maxAttendeeCount,
                   LocalDateTime automaticClosingDatetime,
                   boolean manualClosing,
-                  int reward) {
+                  int reward,
+                  List<String> questions) {
+        this.publisherWalletId = publisherWalletId;
+        this.title = title;
+        this.summary = summary;
         this.desc = desc;
         this.privateAttendeeKey = privateAttendeeKey;
         this.publicAttendeeEmailPattern = publicAttendeeEmailPattern;
@@ -46,9 +62,13 @@ public class Survey {
         this.automaticClosingDatetime = automaticClosingDatetime;
         this.manualClosing = manualClosing;
         this.reward = reward;
+        this.questions = List.copyOf(questions);
     }
 
     public Survey(RegisterSurveyDto dto) {
+        this.publisherWalletId = dto.getPublisherWalletId();
+        this.title = dto.getTitle();
+        this.summary = dto.getSummary();
         this.desc = dto.getDesc();
         this.privateAttendeeKey = dto.getPrivateAttendeeKey();
         this.publicAttendeeEmailPattern = dto.getPublicAttendeeEmailPattern();
@@ -56,5 +76,6 @@ public class Survey {
         this.automaticClosingDatetime = dto.getAutomaticClosingDatetime();
         this.manualClosing = dto.isManualClosing();
         this.reward = dto.getReward();
+        this.questions = List.copyOf(dto.getQuestions());
     }
 }

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
@@ -1,9 +1,12 @@
 package com.thetrustlesstrio.TrustSurveyServer;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -13,11 +16,45 @@ public class Survey {
     private String id;
 
     private String desc;
-    // ...
+
+    private String privateAttendeeKey;
+    private String publicAttendeeEmailPattern; // ex. '@kaist.ac.kr'
+
+    private int maxAttendeeCount;
+
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    private LocalDateTime automaticClosingDatetime;
+
+    private boolean manualClosing;
     private int reward;
 
-    public Survey(String desc, int reward) {
+    // TODO: 현재 참여자 목록 (계좌 id)
+
+    public Survey() {}
+
+    public Survey(String desc,
+                  String privateAttendeeKey,
+                  String publicAttendeeEmailPattern,
+                  int maxAttendeeCount,
+                  LocalDateTime automaticClosingDatetime,
+                  boolean manualClosing,
+                  int reward) {
         this.desc = desc;
+        this.privateAttendeeKey = privateAttendeeKey;
+        this.publicAttendeeEmailPattern = publicAttendeeEmailPattern;
+        this.maxAttendeeCount = maxAttendeeCount;
+        this.automaticClosingDatetime = automaticClosingDatetime;
+        this.manualClosing = manualClosing;
         this.reward = reward;
+    }
+
+    public Survey(RegisterSurveyDto dto) {
+        this.desc = dto.getDesc();
+        this.privateAttendeeKey = dto.getPrivateAttendeeKey();
+        this.publicAttendeeEmailPattern = dto.getPublicAttendeeEmailPattern();
+        this.maxAttendeeCount = dto.getMaxAttendeeCount();
+        this.automaticClosingDatetime = dto.getAutomaticClosingDatetime();
+        this.manualClosing = dto.isManualClosing();
+        this.reward = dto.getReward();
     }
 }

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/HomeController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/HomeController.java
@@ -1,7 +1,11 @@
 package com.thetrustlesstrio.TrustSurveyServer.controller;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 public class HomeController {
@@ -12,4 +16,49 @@ public class HomeController {
         return "home"; // home.html
     }
 
+    @Hidden
+    @GetMapping("test")
+    public String Test(Model model) {
+        // http://localhost:8080/test
+        model.addAttribute("data", "Test!!");
+        return "test"; // test.html
+    }
+
+    @Hidden
+    @GetMapping("test-mvc")
+    public String testMvc(@RequestParam(value = "name") String name, Model model) {
+        // http://localhost:8080/test-mvc?name=trio
+        model.addAttribute("name", name);
+        return "test-template"; // test-template.html
+    }
+
+    @Hidden
+    @GetMapping("test-string")
+    @ResponseBody
+    public String testString(@RequestParam("name") String name) {
+        // http://localhost:8080/test-string?name=trio
+        return "Test " + name; // Raw string
+    }
+
+    @Hidden
+    @GetMapping("test-api")
+    @ResponseBody
+    public HomeController.Test testApi(@RequestParam("name") String name) {
+        HomeController.Test test = new HomeController.Test();
+        test.setName(name);
+        return test; // JSON API
+    }
+
+    @Hidden
+    static class Test {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
 }

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,35 +19,6 @@ public class SurveyController {
 
     @Autowired
     private SurveyRepository surveyRepo;
-
-    @GetMapping("test")
-    public String Test(Model model) {
-        // http://localhost:8080/test
-        model.addAttribute("data", "Test!!");
-        return "test"; // test.html
-    }
-
-    @GetMapping("test-mvc")
-    public String testMvc(@RequestParam(value = "name") String name, Model model) {
-        // http://localhost:8080/test-mvc?name=trio
-        model.addAttribute("name", name);
-        return "test-template"; // test-template.html
-    }
-
-    @GetMapping("test-string")
-    @ResponseBody
-    public String testString(@RequestParam("name") String name) {
-        // http://localhost:8080/test-string?name=trio
-        return "Test " + name; // Raw string
-    }
-
-    @GetMapping("test-api")
-    @ResponseBody
-    public Test testApi(@RequestParam("name") String name) {
-        Test test = new Test();
-        test.setName(name);
-        return test; // JSON API
-    }
 
     @Operation(summary = "get all surveys", description = "등록된 모든 survey를 받아오는 API. 아직은 유저 별로 다르게 보여주는 기능은 없음.")
     @GetMapping("survey")
@@ -71,17 +41,5 @@ public class SurveyController {
         Survey survey = new Survey(reqBody);
         surveyRepo.save(survey);
         return survey;
-    }
-
-    static class Test {
-        private String name;
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
     }
 }

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -1,15 +1,15 @@
 package com.thetrustlesstrio.TrustSurveyServer.controller;
 
+import com.thetrustlesstrio.TrustSurveyServer.RegisterSurveyDto;
 import com.thetrustlesstrio.TrustSurveyServer.Survey;
 import com.thetrustlesstrio.TrustSurveyServer.SurveyRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -50,24 +50,26 @@ public class SurveyController {
         return test; // JSON API
     }
 
-    @Operation(summary = "mongo test", description = "Survey 2개를 Write 해보는 테스트 API")
-    @GetMapping("mongo/test")
+    @GetMapping("survey")
     @ResponseBody
-    public List<Survey> mongoTest() {
-        surveyRepo.deleteAll();
-
-        surveyRepo.save(new Survey("test purpose1", 100));
-        surveyRepo.save(new Survey("test purpose2", 200));
-
+    public List<Survey> listSurvey() {
         return surveyRepo.findAll();
     }
-
-    @GetMapping("mongo/survey")
+    @GetMapping(value = "survey", params = "id")
     @ResponseBody
     public Optional<Survey> getSurvey(@RequestParam("id") String id) {
         return surveyRepo.findById(id);
     }
 
+    @Operation(summary = "register single survey", description = "새로운 Survey 를 등록하는 API")
+    @PostMapping("survey")
+    @ResponseBody
+    public Survey registerSurvey(@RequestBody @Valid RegisterSurveyDto reqBody) {
+        // TODO: requested user should be recorded in Survey object as 'publisher'(?)
+        Survey survey = new Survey(reqBody);
+        surveyRepo.save(survey);
+        return survey;
+    }
 
     static class Test {
         private String name;

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -50,22 +50,24 @@ public class SurveyController {
         return test; // JSON API
     }
 
+    @Operation(summary = "get all surveys", description = "등록된 모든 survey를 받아오는 API. 아직은 유저 별로 다르게 보여주는 기능은 없음.")
     @GetMapping("survey")
     @ResponseBody
     public List<Survey> listSurvey() {
         return surveyRepo.findAll();
     }
-    @GetMapping(value = "survey", params = "id")
+
+    @Operation(summary = "get survey by id", description = "등록된 survey 중에서 id={id} 에 맞는 survey를 받아오는 API. 아직은 유저 별로 다르게 보여주는 기능은 없음.")
+    @GetMapping("survey/{id}")
     @ResponseBody
-    public Optional<Survey> getSurvey(@RequestParam("id") String id) {
+    public Optional<Survey> getSurvey(@PathVariable("id") String id) {
         return surveyRepo.findById(id);
     }
 
-    @Operation(summary = "register single survey", description = "새로운 Survey 를 등록하는 API")
+    @Operation(summary = "register single survey", description = "새로운 survey를 등록하는 API")
     @PostMapping("survey")
     @ResponseBody
     public Survey registerSurvey(@RequestBody @Valid RegisterSurveyDto reqBody) {
-        // TODO: requested user should be recorded in Survey object as 'publisher'(?)
         Survey survey = new Survey(reqBody);
         surveyRepo.save(survey);
         return survey;


### PR DESCRIPTION
Closes #6

## 한 것
* Survey 에 대한 기본적인 DB CR (CRUD - UD) 가 동작하게 했습니다.
* Survey API 에 대한 컨트룰러 라우터를 정돈했습니다.
* Swagger 에서 각 데이터 스키마 (Survey, RegisterSurveyDto) 와 API 설명이 잘 나오게 다듬었습니다.


## 특이사항
로그인 기능이 없다보니 당장은 기본적인 DB CRUD 이상으로 필요한 기능이 떠오르지 않았습니다.
그런데 CRUD 를 짜려고보니 spring mongodb repository 쪽 기본 라이브러리가 다 해줘서 제가 짠 코드는 데이터 스키마 정의하고 컨트룰러 라우터 정리밖에 없습니다.
UD 를 안 짠 이유는 당장 쓸 일이 없을 것 같아서입니다. 필요하면 추가하겠습니다.

## 참고한 레퍼런스
너무 정신없이 검색하면서 해서 참고한 레퍼런스는 정리하지 못 했습니다 ㅎㅎ;;

## TMI
validation 관련 내용 때문에 이것저것 찾다가 이런 내용을 알게 되었습니다.
  * json 형태에는 `@DateTimeFormat` 대신 `@JsonFormat` annotation 을 쓰는 것이 좋다.
  * controller 에서 자동으로 validation 이 되게 하려면 (1) validation 관련 의존성을 추가하고 (2) controller 의 파라미터에 `@Valid` annotation 을 추가하고 (3) 파라미터 타입에 해당하는 객체의 정의에서 검증하고 싶은 필드에 `@NotBlank` 등의 검증용 annotation 을 추가해야한다.