### PR TITLE
CloseSurvey API 추가 & Survey 를 SurveyDto 로 wrapping & SurveyDto.Closed 필드 추가 & Participate API 예외 케이스 처리

### DIFF
--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
@@ -34,6 +34,7 @@ public class Survey {
     private LocalDateTime automaticClosingDatetime;
 
     private boolean manualClosing;
+    private boolean isManuallyClosed;
     private int reward;
 
     private List<String> questions;
@@ -63,6 +64,7 @@ public class Survey {
         this.maxAttendeeCount = maxAttendeeCount;
         this.automaticClosingDatetime = automaticClosingDatetime;
         this.manualClosing = manualClosing;
+        this.isManuallyClosed = false;
         this.reward = reward;
         this.questions = List.copyOf(questions);
         this.responses = new ArrayList<>();
@@ -78,6 +80,7 @@ public class Survey {
         this.maxAttendeeCount = dto.getMaxAttendeeCount();
         this.automaticClosingDatetime = dto.getAutomaticClosingDatetime();
         this.manualClosing = dto.isManualClosing();
+        this.isManuallyClosed = false;
         this.reward = dto.getReward();
         this.questions = List.copyOf(dto.getQuestions());
         this.responses = new ArrayList<>();

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/Survey.java
@@ -7,7 +7,9 @@ import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -84,5 +86,14 @@ public class Survey {
         this.reward = dto.getReward();
         this.questions = List.copyOf(dto.getQuestions());
         this.responses = new ArrayList<>();
+    }
+
+    public boolean isClosed() {
+        if (this.manualClosing && this.isManuallyClosed) {
+            return true;
+        }
+
+        LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
+        return now.isAfter(this.automaticClosingDatetime);
     }
 }

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/SurveyDto.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/SurveyDto.java
@@ -1,0 +1,74 @@
+package com.thetrustlesstrio.TrustSurveyServer;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Getter
+@Setter
+public class SurveyDto {
+    private String id;
+
+    private String publisherWalletId;
+
+    private String title;
+    private String summary;
+    private String desc;
+
+    private String privateAttendeeKey;
+    private String publicAttendeeEmailPattern;
+
+    private int maxAttendeeCount;
+
+    @Schema(type = "LocalDateTime", example = "2023-05-05T13:30:01Z")
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    private LocalDateTime automaticClosingDatetime;
+
+    private boolean manualClosing;
+    private boolean isManuallyClosed;
+
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private boolean isClosed;
+
+    public boolean isClosed() {
+        if (this.manualClosing && this.isManuallyClosed) {
+            return true;
+        }
+
+        LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
+        return now.isAfter(this.automaticClosingDatetime);
+    }
+
+    private int reward;
+
+    private List<String> questions;
+
+    // TODO: 현재 응답 목록 ((참여자1, 응답1), (참여자2, 응답2), ...) -> 게시자만 볼 수 있어야 하는 필드
+    private List<SurveyResponse> responses;
+
+    public SurveyDto(Survey survey) {
+        this.id = survey.getId();
+
+        this.publisherWalletId = survey.getPublisherWalletId();
+        this.title = survey.getTitle();
+        this.summary = survey.getSummary();
+        this.desc = survey.getDesc();
+        this.privateAttendeeKey = survey.getPrivateAttendeeKey();
+        this.publicAttendeeEmailPattern = survey.getPublicAttendeeEmailPattern();
+        this.maxAttendeeCount = survey.getMaxAttendeeCount();
+        this.automaticClosingDatetime = survey.getAutomaticClosingDatetime();
+        this.manualClosing = survey.isManualClosing();
+        this.isManuallyClosed = survey.isManuallyClosed();
+        this.reward = survey.getReward();
+        this.questions = List.copyOf(survey.getQuestions());
+        this.responses = List.copyOf(survey.getResponses());
+    }
+}

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/SurveyDto.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/SurveyDto.java
@@ -2,17 +2,12 @@ package com.thetrustlesstrio.TrustSurveyServer;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 
 @Getter
-@Setter
 public class SurveyDto {
     private String id;
 
@@ -34,18 +29,7 @@ public class SurveyDto {
     private boolean manualClosing;
     private boolean isManuallyClosed;
 
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
     private boolean isClosed;
-
-    public boolean isClosed() {
-        if (this.manualClosing && this.isManuallyClosed) {
-            return true;
-        }
-
-        LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
-        return now.isAfter(this.automaticClosingDatetime);
-    }
 
     private int reward;
 
@@ -67,6 +51,7 @@ public class SurveyDto {
         this.automaticClosingDatetime = survey.getAutomaticClosingDatetime();
         this.manualClosing = survey.isManualClosing();
         this.isManuallyClosed = survey.isManuallyClosed();
+        this.isClosed = survey.isClosed();
         this.reward = survey.getReward();
         this.questions = List.copyOf(survey.getQuestions());
         this.responses = List.copyOf(survey.getResponses());

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -4,12 +4,14 @@ import com.thetrustlesstrio.TrustSurveyServer.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Tag(name = "Survey Controller", description = "Survey 관련 컨트롤러")
 @Controller
@@ -21,30 +23,36 @@ public class SurveyController {
     @Operation(summary = "get all surveys", description = "등록된 모든 survey를 받아오는 API. 아직은 유저 별로 다르게 보여주는 기능은 없음.")
     @GetMapping("survey")
     @ResponseBody
-    public List<Survey> listSurvey() {
-        return surveyRepo.findAll();
+    public List<SurveyDto> listSurvey() {
+        return surveyRepo.findAll().stream()
+                .map(survey -> new SurveyDto(survey))
+                .collect(Collectors.toList());
     }
 
     @Operation(summary = "get survey by id", description = "등록된 survey 중에서 id={id} 에 맞는 survey를 받아오는 API. 아직은 유저 별로 다르게 보여주는 기능은 없음.")
     @GetMapping("survey/{id}")
     @ResponseBody
-    public Optional<Survey> getSurvey(@PathVariable("id") String id) {
-        return surveyRepo.findById(id);
+    public Optional<SurveyDto> getSurvey(@PathVariable("id") String id) {
+        Optional<Survey> surveyOpt = surveyRepo.findById(id);
+        if (surveyOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new SurveyDto(surveyOpt.get()));
     }
 
     @Operation(summary = "register single survey", description = "새로운 survey를 등록하는 API")
     @PostMapping("survey")
     @ResponseBody
-    public Survey registerSurvey(@RequestBody @Valid RegisterSurveyDto reqBody) {
+    public SurveyDto registerSurvey(@RequestBody @Valid RegisterSurveyDto reqBody) {
         Survey survey = new Survey(reqBody);
         surveyRepo.save(survey);
-        return survey;
+        return new SurveyDto(survey);
     }
 
     @Operation(summary = "Participate single survey", description = "새로운 survey애 참여")
     @PostMapping("participate")
     @ResponseBody
-    public Survey participateSurvey(@RequestBody @Valid ParticipateSurveyDto reqBody) {
+    public SurveyDto participateSurvey(@RequestBody @Valid ParticipateSurveyDto reqBody) {
         SurveyResponse surveyResponse = new SurveyResponse(reqBody.getParticipantWalletId(), reqBody.getAnswers());
         Survey survey = surveyRepo.findById(reqBody.getSurveyId()).get();
 
@@ -52,7 +60,33 @@ public class SurveyController {
             survey.getResponses().add(surveyResponse);
             surveyRepo.save(survey);
         }
-        return survey;
+        return new SurveyDto(survey);
+    }
+
+    @Operation(summary = "Close single survey manually", description = "publisher가 자신의 survey를 수동으로 종료")
+    @GetMapping("survey/{id}/close")
+    public SurveyDto closeSurvey(@PathVariable("id") @NotBlank String surveyId, @RequestParam("userWalletId") @NotBlank String userWalletId) {
+        Survey survey = surveyRepo.findById(surveyId).get();
+
+        // TODO: Better validation to check whether requester is the publisher of the survey
+        if (!survey.getPublisherWalletId().equals(userWalletId)) {
+            // TODO: Better error handling?
+            throw new Error("Only publisher can manually close this survey");
+        }
+
+        // Does the survey have manual closing option?
+        if (!survey.isManualClosing()) {
+            // TODO: Better error handling?
+            throw new Error("This survey doesn't have manual closing option");
+        }
+
+        if (survey.isManuallyClosed()) {
+            return new SurveyDto(survey);
+        }
+
+        survey.setManuallyClosed(true);
+        surveyRepo.save(survey);
+        return new SurveyDto(survey);
     }
 
     @Operation(summary = "Remove all surveys", description = "(테스트용) 모든 설문 데이터를 삭제")

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -62,6 +62,9 @@ public class SurveyController {
 
         // TODO: Close when it reaches maximum attendees?
 
+        if (survey.getResponses().stream().anyMatch(res -> res.getParticipantWalletId().equals(surveyResponse.getParticipantWalletId()))) {
+            throw new Error("Duplicated participation is now allowed");
+        }
         if (survey.getQuestions().size() != surveyResponse.getAnswers().size()) {
             throw new Error("The number of answers doesn't match with the number of questions");
         }

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -62,6 +62,9 @@ public class SurveyController {
 
         // TODO: Close when it reaches maximum attendees?
 
+        if (survey.getQuestions().size() != surveyResponse.getAnswers().size()) {
+            throw new Error("The number of answers doesn't match with the number of questions");
+        }
         if (survey.getMaxAttendeeCount() > survey.getResponses().size()) {
             survey.getResponses().add(surveyResponse);
             surveyRepo.save(survey);

--- a/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
+++ b/src/main/java/com/thetrustlesstrio/TrustSurveyServer/controller/SurveyController.java
@@ -49,12 +49,18 @@ public class SurveyController {
         return new SurveyDto(survey);
     }
 
-    @Operation(summary = "Participate single survey", description = "새로운 survey애 참여")
+    @Operation(summary = "Participate single survey", description = "새로운 survey에 참여")
     @PostMapping("participate")
     @ResponseBody
     public SurveyDto participateSurvey(@RequestBody @Valid ParticipateSurveyDto reqBody) {
         SurveyResponse surveyResponse = new SurveyResponse(reqBody.getParticipantWalletId(), reqBody.getAnswers());
         Survey survey = surveyRepo.findById(reqBody.getSurveyId()).get();
+
+        if (survey.isClosed()) {
+            throw new Error("This survey is closed.");
+        }
+
+        // TODO: Close when it reaches maximum attendees?
 
         if (survey.getMaxAttendeeCount() > survey.getResponses().size()) {
             survey.getResponses().add(surveyResponse);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.data.mongodb.database = trust-survey-test
 #spring.data.mongodb.authentication-database = admin
 #spring.data.mongodb.username =
 #spring.data.mongodb.password =
+
+server.error.include-message = always
+server.error.include-binding-errors = always


### PR DESCRIPTION
Close #9 

시간 관계상 하나의 PR 로 드립니다.

## 작업 내용
* Close Survey API 를 추가했습니다. (manual close)
* SurveyDto 라는 Survey 의 wrapper 를 만들어서 서버 밖으로 나가는 Survey 를 SurveyDto 로 바꿨습니다.
  * Why? -> DB 에 저장되는 정보와 서버 밖으로 나가는 정보를 다르게 해주기 위함입니다.
* Closed 필드를 서버에서 계산하여 SurveyDto 에 추가했습니다. (조건 = manually closed || automatically closed)
  * Closed 필드는 (1) manualClosing, (2) isManuallyClosed, (3) automaticClosingDatetime, (4) 서버 시간에 의존하기 때문에 DB 에 저장하는 것은 어색합니다.
  * 그래서 Survey.Closed 를 만들지 않고 SurveyDto.Closed 만 만들었습니다.
* Participate API 에서의 몇몇 예외 케이스를 추가했습니다.
  * Closed Survey 이면 참가시키지 않습니다.
  * 참가 시에 len(questions) 와 len(response.answers) 가 맞지 않으면 참가시키지 않습니다.
  * 이미 참가한 participant 이면 참가시키지 않습니다.
* controller 에서 에러가 던져지면 에러메시지를 response 에 담도록 했습니다.
  * application.properties 참고 (출처 - https://reflectoring.io/spring-boot-exception-handling/) 

## 테스트 사항
데이터 초기화

설문 리스트 확인 → 비어있음

설문 1개 등록 → 성공

설문 리스트 확인 → 1개 등록됨

설문 참가 → 성공

설문 리스트 확인 → 답변이 잘 등록된 것 확인

다른 유저로 manual close 시도 → 에러 메시지 잘 오는 것 확인

자동 종료 시간이 지난 뒤 설문 확인 → closed: true 로 된 것 확인

닫힌 설문에 참가 못하게 처리 → 막히는 것 확인

질문 갯수와 안 맞으면 참가 못하게 처리 → 막히는 것 확인

이미 참가했으면 참가 못하게 처리 → 막히는 것 확인